### PR TITLE
Gnome shell 3.10 and 3.12 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,10 +1,10 @@
 {
-    "shell-version": ["3.2", "3.4", "3.6", "3.8"],
+    "shell-version": ["3.2", "3.4", "3.6", "3.8", "3.10", "3.12"],
     "uuid": "workspaceNavigator@smotko.si",
     "localedir": "/usr/share/locale",
     "original-author": "smotko.si",
     "name": "Workspace Navigator",
     "description": "Allow selection of workspaces with up and down arrow keys in overlay mode",
     "url": "http://github.com/Smotko/gnome-shell-extension-workspaceNavigator",
-    "version": "1.7"
+    "version": "1.7.1"
 }


### PR DESCRIPTION
I can't live without it, so I manually added to `metadata.json`
